### PR TITLE
Add BasePlotMixin

### DIFF
--- a/src/discontinuum/engines/base.py
+++ b/src/discontinuum/engines/base.py
@@ -2,34 +2,80 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import functools
+from abc import ABC, abstractmethod
+
+from discontinuum.data_manager import DataManager
+from discontinuum.pipeline import StandardErrorPipeline, StandardPipeline
+
 if TYPE_CHECKING:
     from typing import Dict, Optional
+    from xarray import DataArray, Dataset
 
-import functools
 
-
-class BaseModel:
+class BaseModel(ABC):
     def __init__(self, model_config: Optional[Dict] = None):
-        """ """
+        """Base class for all models.
+
+        Parameters
+        ----------
+        model_config : dict, optional
+            Configuration for the model. The default is None.
+        """
         if model_config is None:
             model_config = {}
 
-        self.dm = None
         self.model_config = model_config
+        self.dm = None
         self.is_fitted = False
 
-    def fit(self, X, y=None):
+    @abstractmethod
+    def fit(self,
+            covariates: Dataset,
+            target: Dataset,
+            **kwargs,
+            ):
+        """Fit model to data.
+
+        Parameters
+        ----------
+        covariates : Dataset
+            Covariates for training.
+        target : Dataset
+            Target data for training.
+        kwargs : dict
+            Additional keyword arguments.
+        """
         self.is_fitted = True
         return self
 
-    def predict(self, X):
+    @abstractmethod
+    def predict(self, covariates: Dataset) -> DataArray:
+        """Use a fitted model to make predictions on new data.
+
+        Parameters
+        ----------
+        covariates : Dataset
+            Covariates for prediction.
+        """
         pass
 
+    @abstractmethod
     def build_model(self, X, y):
+        """
+        TODO Sometimes this sets self.model and sometimes this returns model.
+        Not sure that we can standardize the behavior for different engines.
+        """
         pass
 
+    @abstractmethod
     def build_datamanager(self):
-        pass
+        """Build DataManager for the model."""
+        self.dm = DataManager(
+            target_pipeline=StandardPipeline,
+            error_pipeline=StandardErrorPipeline,
+            covariate_pipelines=StandardPipeline,
+        )
 
 
 def is_fitted(func):

--- a/src/discontinuum/engines/gpytorch.py
+++ b/src/discontinuum/engines/gpytorch.py
@@ -14,7 +14,6 @@ from discontinuum.engines.base import BaseModel, is_fitted
 
 if TYPE_CHECKING:
     from typing import Dict, Optional
-
     from xarray import Dataset
 
 
@@ -50,9 +49,9 @@ class MarginalGPyTorch(BaseModel):
         Parameters
         ----------
         covariates : Dataset
-            Covariates for prediction.
+            Covariates for training.
         target : Dataset
-            Target data for prediction.
+            Target data for training.
         iterations : int, optional
             Number of iterations for optimization. The default is 100.
         optimizer : str, optional
@@ -95,8 +94,24 @@ class MarginalGPyTorch(BaseModel):
             optimizer.step()
 
     @is_fitted
-    def predict(self, covariates, diag=True, pred_noise=False) -> DataArray:
-        """Uses the fitted model to make predictions on new data."""
+    def predict(self,
+                covariates: Dataset,
+                diag=True,
+                pred_noise=False,
+                ) -> DataArray:
+        """Uses the fitted model to make predictions on new data.
+
+        Parameters
+        ----------
+        covariates : Dataset
+            Covariates for prediction.
+        diag : bool, optional
+            Return only the diagonal of the covariance matrix.
+            The default is True.
+        pred_noise : bool, optional
+            Include measurement uncertainty in the prediction.
+            The default is False.
+        """
         Xnew = torch.tensor(
             self.dm.Xnew(covariates),
             dtype=torch.float32,

--- a/src/discontinuum/plot.py
+++ b/src/discontinuum/plot.py
@@ -73,7 +73,7 @@ class BasePlotMixin:
 
     @is_fitted
     def plot(self, covariates: Dataset, ci: float = 0.95, ax: Optional[Axes] = None):
-        """Plot predicted concentration versus time.
+        """Plot predicted data versus time.
 
         Parameters
         ----------

--- a/src/discontinuum/plot.py
+++ b/src/discontinuum/plot.py
@@ -1,0 +1,119 @@
+"""Plotting functions"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import matplotlib.pyplot as plt
+import numpy as np
+from discontinuum.engines.base import is_fitted
+from scipy.stats import norm
+from xarray import DataArray
+from xarray.plot.utils import label_from_attrs
+
+if TYPE_CHECKING:
+    from typing import Dict, Optional
+
+    from matplotlib.pyplot import Axes
+    from xarray import Dataset
+
+
+DEFAULT_FIGSIZE = (5, 5)
+NARROW_LINE = 1
+REGULAR_LINE = NARROW_LINE * 1.5
+
+
+class BasePlotMixin:
+    """Mixin plotting functions for Model class"""
+
+    @staticmethod
+    def setup_plot(ax: Optional[Axes] = None):
+        """Sets up figure and axes for rating curve plot.
+
+        Parameters
+        ----------
+        ax : Axes, optional
+            Pre-defined matplotlib axes.
+
+        Returns
+        -------
+        ax : Axes
+            Generated matplotlib axes.
+        """
+        if ax is None:
+            _, ax = plt.subplots(1, figsize=DEFAULT_FIGSIZE)
+
+        return ax
+
+    @is_fitted
+    def plot_observations(self, ax: Optional[Axes] = None, **kwargs):
+        """Plot observations versus time.
+
+        Parameters
+        ----------
+        ax : Axes, optional
+            Pre-defined matplotlib axes.
+
+        Returns
+        -------
+        ax : Axes
+            Generated matplotlib axes.
+
+        """
+        # TODO provide easier access to data
+        self.dm.data.target.plot.scatter(
+            y=self.dm.data.target.name,
+            c="k",
+            s=5,
+            linewidths=0.5,
+            edgecolors="white",
+            ax=ax,
+            **kwargs,
+        )
+
+    @is_fitted
+    def plot(self, covariates: Dataset, ci: float = 0.95, ax: Optional[Axes] = None):
+        """Plot predicted concentration versus time.
+
+        Parameters
+        ----------
+        covariates : Dataset
+            Covariates.
+        ci : float, optional
+            Confidence interval. The default is 0.95.
+        ax : Axes, optional
+            Pre-defined matplotlib axes.
+
+        Returns
+        -------
+        ax : Axes
+            Generated matplotlib axes.
+        """
+        ax = self.setup_plot(ax)
+
+        mu, se = self.predict(covariates, diag=True, pred_noise=True)
+
+        target = DataArray(
+            mu,
+            coords=[covariates.time],
+            dims=["time"],
+            attrs=self.dm.data.target.attrs,
+        )
+
+        # compute confidence bounds
+        lower, upper = self.dm.error_pipeline.ci(target, se, ci=ci)
+
+        target.plot.line(ax=ax, lw=1, zorder=2)
+
+        ax.fill_between(
+            target["time"],
+            lower,
+            upper,
+            color="b",
+            alpha=0.1,
+            zorder=1,
+        )
+
+        self.plot_observations(ax, zorder=3)
+
+        return ax

--- a/src/discontinuum/plot.py
+++ b/src/discontinuum/plot.py
@@ -28,7 +28,7 @@ class BasePlotMixin:
 
     @staticmethod
     def setup_plot(ax: Optional[Axes] = None):
-        """Sets up figure and axes for rating curve plot.
+        """Sets up figure and axes for plot.
 
         Parameters
         ----------

--- a/src/loadest_gp/models/base.py
+++ b/src/loadest_gp/models/base.py
@@ -16,6 +16,7 @@ from discontinuum.pipeline import (
 if TYPE_CHECKING:
     from typing import Literal
 
+
 @dataclass
 class ModelConfig:
     """ """

--- a/src/loadest_gp/models/gpytorch.py
+++ b/src/loadest_gp/models/gpytorch.py
@@ -47,7 +47,7 @@ class LoadestGPMarginalGPyTorch(
         #     noise_prior=noise_prior,
         # )
 
-        noise = 0.1**2 * torch.ones(y.shape[0]).reshape(1,-1)
+        noise = 0.1**2 * torch.ones(y.shape[0]).reshape(1, -1)
         self.likelihood = gpytorch.likelihoods.FixedNoiseGaussianLikelihood(
             noise=noise,
             learn_additional_noise=False,


### PR DESCRIPTION
Adds a BasePlotMixin with model-agnostic versions of `plot` and `plot_observations`. Also implements a method within `ErrorPipeline` to compute prediction bounds, rather than computing them within `plot`.

Everything looked fine when I ran the demo. GIve it a once over, then go ahead and merge and rebase `rating-gp`.