### PR TITLE
Add NoOpMean for rating-gp

### DIFF
--- a/src/discontinuum/engines/gpytorch.py
+++ b/src/discontinuum/engines/gpytorch.py
@@ -17,6 +17,11 @@ if TYPE_CHECKING:
     from xarray import Dataset
 
 
+class NoOpMean(gpytorch.means.Mean):
+    def forward(self, x):
+        return x.squeeze(-1)
+ 
+
 class LatentGPyTorch(BaseModel):
     def __init__(
         self,

--- a/src/rating_gp/models/gpytorch.py
+++ b/src/rating_gp/models/gpytorch.py
@@ -1,12 +1,13 @@
 import gpytorch
 import numpy as np
 import torch
-from discontinuum.engines.gpytorch import MarginalGPyTorch
+from discontinuum.engines.gpytorch import MarginalGPyTorch, NoOpMean
 
 from gpytorch.kernels import (
     MaternKernel,
     ScaleKernel,
 )
+
 
 from rating_gp.models.base import RatingDataMixin, ModelConfig
 from rating_gp.plot import RatingPlotMixin
@@ -83,7 +84,8 @@ class ExactGPModel(gpytorch.models.ExactGP):
         # might try a constant mean with a linear * Matern kernel.
 
         #self.mean_module = gpytorch.means.ConstantMean()
-        self.mean_module = gpytorch.means.LinearMean(input_size=1)
+        #self.mean_module = gpytorch.means.LinearMean(input_size=1)
+        self.mean_module = NoOpMean()
         self.covar_module = self.cov_kernel()
 
     def forward(self, x):


### PR DESCRIPTION
This shouldn't affect performance but makes the parameters more straightforward by removing the bias and weights added in by GPyTorch's `LinearMean`.