### PR TITLE
Remove redundant reshape

### DIFF
--- a/src/discontinuum/data_manager.py
+++ b/src/discontinuum/data_manager.py
@@ -107,6 +107,7 @@ class DataManager:
 
     def y_t(self, y: ArrayLike) -> Dataset:
         """Convenience function for DataManager.target.untransform"""
+        # TODO handle reshaping in pipeline
         return self.target_pipeline.inverse_transform(y.reshape(-1, 1))
 
     def get_dim(self, dim: str, index="time") -> int:

--- a/src/discontinuum/engines/gpytorch.py
+++ b/src/discontinuum/engines/gpytorch.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 class NoOpMean(gpytorch.means.Mean):
     def forward(self, x):
         return x.squeeze(-1)
- 
+
 
 class LatentGPyTorch(BaseModel):
     def __init__(
@@ -139,8 +139,7 @@ class MarginalGPyTorch(BaseModel):
             var = observed_pred.variance
 
         target = self.dm.y_t(mu)
-        # TODO the reshape should be done in the pipeline
-        se = self.dm.error_pipeline.inverse_transform(var.reshape(-1, 1))
+        se = self.dm.error_pipeline.inverse_transform(var)
 
         return target, se
 
@@ -168,6 +167,7 @@ class MarginalGPyTorch(BaseModel):
         x_time = torch.linspace(x_min[time_dim], x_max[time_dim], n_time)
         x_cov = torch.linspace(x_min[covariate_dim], x_max[covariate_dim], n_cov)
 
+        # expects a 1D vector
         X_grid = torch.cartesian_prod(x_time, x_cov)
 
         self.model.eval()
@@ -179,8 +179,9 @@ class MarginalGPyTorch(BaseModel):
             # var = observed_pred.variance
 
         target = self.dm.y_t(mu)
-        # TODO return a Dataset with the correct shape
         target = target.data.reshape(n_time, n_cov)
+
+        # TODO handle reshaping in pipeline
         index = self.dm.covariate_pipelines["time"].inverse_transform(x_time.reshape(-1, 1))
         covariate = self.dm.covariate_pipelines[covariate].inverse_transform(x_cov.reshape(-1, 1))
 

--- a/src/discontinuum/pipeline.py
+++ b/src/discontinuum/pipeline.py
@@ -9,7 +9,7 @@ from numpy.typing import ArrayLike
 from scipy.stats import norm
 from sklearn.base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin
 from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import FunctionTransformer, StandardScaler
+from sklearn.preprocessing import StandardScaler
 from xarray import DataArray
 
 
@@ -120,12 +120,17 @@ class TimeTransformer(BaseTransformer):
 
 
 class ShapeTransformer(OneToOneFeatureMixin, BaseTransformer):
-    """Reshape a 1D array to 2D."""
+    """Reshape a 1D array to 2D.
+
+    Reshaping is a persistent issue that is still handled poorly.
+    One issue is StandardScaler expects a 2D array, and a lot of
+    the reshaping is to work around that.
+    """
     def transform(self, X):
         return X.reshape(-1, 1)
 
     def inverse_transform(self, X):
-        return X.ravel()
+        return X.squeeze()
 
 
 class SquareTransformer(OneToOneFeatureMixin, BaseTransformer):


### PR DESCRIPTION
This isn't the sweeping fix I'd hoped for, but I suggest we go ahead with the PR because I think I've isolated the pathology to `sklearn.StandardScaler`, which enforces certain shape patterns that don't conform with the rest of `discontinuum`.

Longterm we might need to reimplement `StandardScaler` or else sandwich it between reshaping transformers in the pipeline.