### PR TITLE
Add orthogonal RFF noise model with per-dimension scaling

### DIFF
--- a/src/discontinuum/noise/__init__.py
+++ b/src/discontinuum/noise/__init__.py
@@ -1,0 +1,5 @@
+"""Noise models for discontinuum."""
+
+from .orthogonal_rff import OrthogonalRFFNoise
+
+__all__ = ["OrthogonalRFFNoise"]

--- a/src/discontinuum/noise/orthogonal_rff.py
+++ b/src/discontinuum/noise/orthogonal_rff.py
@@ -1,0 +1,91 @@
+"""Orthogonal random Fourier feature noise model."""
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Sequence
+
+import torch
+
+
+class OrthogonalRFFNoise:
+    """Approximate noise using orthogonal random Fourier features.
+
+    This class generates an orthogonal random Fourier feature (RFF) mapping
+    which can be used to approximate stationary covariance functions. Each
+    input dimension can be scaled individually via the ``scales`` argument.
+
+    Parameters
+    ----------
+    input_dim : int
+        Dimension of the input space.
+    num_features : int
+        Number of random features to draw.
+    scales : Sequence[float], optional
+        Per-dimension scaling factors. If ``None``, all dimensions are scaled
+        by 1.0.
+    seed : int, optional
+        Random seed for reproducibility.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        num_features: int,
+        scales: Optional[Sequence[float]] = None,
+        seed: Optional[int] = None,
+    ) -> None:
+        self.input_dim = int(input_dim)
+        self.num_features = int(num_features)
+
+        if scales is None:
+            scales = torch.ones(self.input_dim, dtype=torch.float32)
+        else:
+            scales = torch.as_tensor(scales, dtype=torch.float32)
+            if scales.numel() != self.input_dim:
+                raise ValueError("Length of scales must equal input_dim")
+        self.scales = scales
+
+        self.seed = seed
+        self._init_features()
+
+    def _init_features(self) -> None:
+        gen = torch.Generator()
+        if self.seed is not None:
+            gen.manual_seed(int(self.seed))
+
+        # Draw random weights in blocks so that within each block the
+        # feature vectors are orthogonal. This follows the approach of
+        # "Orthogonal Random Features" where the random frequencies are
+        # generated from orthogonal matrices.
+        d = self.input_dim
+        n_blocks = math.ceil(self.num_features / d)
+        blocks = []
+        for _ in range(n_blocks):
+            g = torch.randn(d, d, generator=gen)
+            q, _ = torch.linalg.qr(g)
+            blocks.append(q)
+        w = torch.cat(blocks, dim=1)[:, : self.num_features]
+
+        # Apply per-dimension scaling. Each row corresponds to an input dim.
+        self.weight = w / self.scales[:, None]
+
+        # Random phase for each feature
+        self.phase = 2 * math.pi * torch.rand(self.num_features, generator=gen)
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        """Compute the orthogonal RFF features for ``x``.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor with shape ``(n_samples, input_dim)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Feature matrix of shape ``(n_samples, num_features)``.
+        """
+        x = torch.as_tensor(x, dtype=torch.float32)
+        proj = x @ self.weight
+        return math.sqrt(2.0 / self.num_features) * torch.cos(proj + self.phase)

--- a/tests/test_orthogonal_rff_noise.py
+++ b/tests/test_orthogonal_rff_noise.py
@@ -1,0 +1,28 @@
+import torch
+
+from discontinuum.noise import OrthogonalRFFNoise
+
+
+def test_per_dimension_scaling():
+    input_dim = 3
+    num_features = 16
+    scales = torch.tensor([2.0, 0.5, 1.5])
+    x = torch.randn(10, input_dim)
+
+    model_scaled = OrthogonalRFFNoise(
+        input_dim=input_dim,
+        num_features=num_features,
+        scales=scales,
+        seed=0,
+    )
+    features_scaled = model_scaled(x)
+
+    # Equivalent computation by scaling the inputs instead of providing scales
+    model_unscaled = OrthogonalRFFNoise(
+        input_dim=input_dim,
+        num_features=num_features,
+        seed=0,
+    )
+    features_unscaled = model_unscaled(x / scales)
+
+    assert torch.allclose(features_scaled, features_unscaled, atol=1e-5)


### PR DESCRIPTION
## Summary
- implement orthogonal random Fourier feature noise model with per-dimension scaling
- expose new noise module
- add tests verifying dimension-wise scaling behavior

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8bf6c0f8c832d82a831476faec31b