### PR TITLE
Restrict time lengthscale priors

### DIFF
--- a/src/discontinuum/engines/gpytorch.py
+++ b/src/discontinuum/engines/gpytorch.py
@@ -373,7 +373,7 @@ class MarginalGPyTorch(BaseModel):
                 output = self.model(train_x)
                 
                 try:
-                    nll = -mll(output, train_y)
+                    nll = -mll(output, train_y, train_x)
                 except Exception as e:
                     nan_loss_counter += 1
                     if nan_loss_counter > 10:
@@ -667,7 +667,7 @@ class MarginalGPyTorch(BaseModel):
         self.likelihood.eval()
 
         with torch.no_grad(), gpytorch.settings.fast_pred_var():
-            observed_pred = self.likelihood(self.model(x))
+            observed_pred = self.likelihood(self.model(x), x)
             mu = observed_pred.mean
             var = observed_pred.variance
 

--- a/src/rating_gp/models/base.py
+++ b/src/rating_gp/models/base.py
@@ -19,7 +19,7 @@ from discontinuum.pipeline import (
 class ModelConfig:
     """ """
     transform: Literal["log", "standard"] = "log"
-    noise_model: Literal["heteroskedastic", "gp", "fixed"] = "heteroskedastic"
+    noise_model: Literal["heteroskedastic", "gp", "fixed"] = "gp"
 
 
 class RatingDataMixin:

--- a/src/rating_gp/models/base.py
+++ b/src/rating_gp/models/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Literal
 
 from dataclasses import dataclass
 
@@ -14,9 +14,6 @@ from discontinuum.pipeline import (
     UnitPipeline,
 )
 # from rating_gp.pipeline import LogUncertaintyPipeline
-
-if TYPE_CHECKING:
-    from typing import Literal
 
 @dataclass
 class ModelConfig:

--- a/src/rating_gp/models/base.py
+++ b/src/rating_gp/models/base.py
@@ -19,6 +19,7 @@ from discontinuum.pipeline import (
 class ModelConfig:
     """ """
     transform: Literal["log", "standard"] = "log"
+    noise_model: Literal["heteroskedastic", "gp", "fixed"] = "heteroskedastic"
 
 
 class RatingDataMixin:

--- a/src/rating_gp/models/gpytorch.py
+++ b/src/rating_gp/models/gpytorch.py
@@ -15,6 +15,7 @@ from gpytorch.priors import (
     GammaPrior,
     HalfNormalPrior,
     NormalPrior,
+    SmoothedBoxPrior,
 )
 
 from rating_gp.models.base import RatingDataMixin, ModelConfig
@@ -73,13 +74,10 @@ class RatingGPMarginalGPyTorch(
         if y_unc is not None:
             noise = y_unc
         else:
-            noise = 0.1**2 * torch.ones(y.shape[0]).reshape(1, -1)
-        # TODO: Fix "GPInputWarning: You have passed data through a 
-        # FixedNoiseGaussianLikelihood that did not match the size of the fixed
-        # noise, *and* you did not specify noise. This is treated as a no-op."
+            noise = 0.1 ** 2 * torch.ones(y.shape[0]).reshape(1, -1)
+
         self.likelihood = gpytorch.likelihoods.FixedNoiseGaussianLikelihood(
             noise=noise,
-            #learn_additional_noise=False,
             learn_additional_noise=True,
             noise_prior=gpytorch.priors.HalfNormalPrior(scale=0.03),
         )
@@ -162,7 +160,7 @@ class RatingGPMarginalGPyTorch(
             self.likelihood.eval()
             try:
                 with gpytorch.settings.fast_pred_var():
-                    mean = self.likelihood(self.model(x_grid)).mean
+                    mean = self.likelihood(self.model(x_grid), x_grid).mean
             finally:
                 if was_model_training:
                     self.model.train()
@@ -207,21 +205,21 @@ class ExactGPModel(gpytorch.models.ExactGP):
 
         self.mean_module = NoOpMean()
 
-        # Use stage (not y) for sigmoid kernel constraint
-        stage = train_x[:, self.stage_dim[0]]#.cpu().numpy()
-        b_min = np.quantile(stage, 0.10)
-        b_max = np.quantile(stage, 0.90)
- 
+        # Use stage (not y) to derive a prior range for the sigmoid switch point
+        stage = train_x[:, self.stage_dim[0]]
+        b_min = float(np.quantile(stage, 0.10))
+        b_max = float(np.quantile(stage, 0.90))
+        b_prior = SmoothedBoxPrior(b_min, b_max, sigma=0.05)
+
         # Create sigmoid kernel for gating (shared switchpoint)
         sigmoid_lower = SigmoidKernel(
             active_dims=self.stage_dim,
-            b_constraint=gpytorch.constraints.Interval(b_min, b_max),
+            b_prior=b_prior,
         )
- 
+
         sigmoid_upper = InvertedSigmoidKernel(
             sigmoid_kernel=sigmoid_lower,
             active_dims=self.stage_dim,
-            b_constraint=gpytorch.constraints.Interval(b_min, b_max),
         )
  
         # Compose the upper kernel branch and wrap in LogWarpKernel
@@ -237,7 +235,6 @@ class ExactGPModel(gpytorch.models.ExactGP):
         lower_kernel = (
             self.cov_shift(
                 eta_prior=HalfNormalPrior(scale=2.0),
-                time_prior=GammaPrior(concentration=1, rate=7),
             )
         )
 
@@ -278,6 +275,9 @@ class ExactGPModel(gpytorch.models.ExactGP):
         if eta_prior is None:
             eta_prior = HalfNormalPrior(scale=1)
 
+        if ls_prior is None:
+            ls_prior = SmoothedBoxPrior(0.1, 5.0)
+
         # Base Matern kernel for long-term trends
         return ScaleKernel(
             MaternKernel(
@@ -290,10 +290,10 @@ class ExactGPModel(gpytorch.models.ExactGP):
     
     def cov_shift(self, eta_prior=None, time_prior=None):
         if eta_prior is None:
-            eta_prior = HalfNormalPrior(scale=0.3) 
+            eta_prior = HalfNormalPrior(scale=0.3)
 
         if time_prior is None:
-            time_prior = GammaPrior(concentration=1, rate=7)
+            time_prior = SmoothedBoxPrior(0.1, 1.0, sigma=0.05)
 
         return ScaleKernel(
             MaternKernel(

--- a/src/rating_gp/models/noise.py
+++ b/src/rating_gp/models/noise.py
@@ -96,14 +96,17 @@ class GaussianProcessNoise(Noise):
         super().__init__()
         if kernel is None:
             if lengthscale_prior is None:
-                lengthscale_prior = SmoothedBoxPrior(0.05, 0.5)
+                lengthscale_prior = SmoothedBoxPrior(0.01, 0.25)
             if outputscale_prior is None:
-                outputscale_prior = SmoothedBoxPrior(1e-6, 0.25)
+                outputscale_prior = SmoothedBoxPrior(1e-6, 4.0)
             base_kernel = RBFKernel(ard_num_dims=2, lengthscale_prior=lengthscale_prior)
             kernel = ScaleKernel(base_kernel, outputscale_prior=outputscale_prior)
         self.covar_module = kernel
 
     def forward(self, x, shape=None, noise=None, **kwargs):
+        # some call sites provide inputs as a singleton list/tuple
+        if isinstance(x, (list, tuple)):
+            x = x[0]
         return self.covar_module(x)
 
 

--- a/src/rating_gp/models/noise.py
+++ b/src/rating_gp/models/noise.py
@@ -1,0 +1,129 @@
+import torch
+import gpytorch
+from gpytorch.likelihoods import _GaussianLikelihoodBase
+from gpytorch.likelihoods.noise_models import Noise
+from gpytorch.constraints import GreaterThan
+from gpytorch.kernels import ScaleKernel, RBFKernel
+from gpytorch.priors import SmoothedBoxPrior
+from linear_operator.operators import DiagLinearOperator
+
+
+class LearnedHeteroskedasticNoise(Noise):
+    """Learnable per-observation noise model.
+
+    Stores a noise parameter for each training observation and optimizes it
+    during GP training. The noise values are constrained to be positive to
+    ensure numerical stability.
+    """
+
+    def __init__(self, noise: torch.Tensor, noise_prior=None, noise_constraint=None):
+        super().__init__()
+        if noise_constraint is None:
+            noise_constraint = GreaterThan(1e-4)
+        noise = noise.reshape(-1)
+        self.register_parameter(
+            name="raw_noise",
+            parameter=torch.nn.Parameter(torch.zeros_like(noise))
+        )
+        self.register_constraint("raw_noise", noise_constraint)
+        if noise_prior is not None:
+            self.register_prior(
+                "noise_prior", noise_prior, self._noise_param, self._noise_closure
+            )
+        self._set_noise(noise)
+
+    def _noise_param(self, m):
+        return m.noise
+
+    def _noise_closure(self, m, v):
+        return m._set_noise(v)
+
+    @property
+    def noise(self):
+        n = self.raw_noise_constraint.transform(self.raw_noise)
+        return torch.nan_to_num(n, nan=1e-4)
+
+    def _set_noise(self, value):
+        if not torch.is_tensor(value):
+            value = torch.as_tensor(value).to(self.raw_noise)
+        self.initialize(raw_noise=self.raw_noise_constraint.inverse_transform(value))
+        return self
+
+    def forward(self, *params, shape=None, noise=None, **kwargs):
+        if noise is not None:
+            return DiagLinearOperator(noise.reshape(-1))
+        if shape is not None and shape[-1] != self.noise.numel():
+            default = self.noise.mean().repeat(shape[-1])
+            return DiagLinearOperator(default)
+        return DiagLinearOperator(self.noise)
+
+
+class HeteroskedasticGaussianLikelihood(_GaussianLikelihoodBase):
+    """Gaussian likelihood with per-observation learnable noise."""
+
+    def __init__(self, noise: torch.Tensor, noise_prior=None, noise_constraint=None):
+        noise_covar = LearnedHeteroskedasticNoise(
+            noise=noise,
+            noise_prior=noise_prior,
+            noise_constraint=noise_constraint,
+        )
+        super().__init__(noise_covar=noise_covar)
+
+    @property
+    def noise(self):
+        return self.noise_covar.noise
+
+    @noise.setter
+    def noise(self, value):
+        self.noise_covar._set_noise(value)
+
+
+class GaussianProcessNoise(Noise):
+    """Noise model using a Gaussian process over time and stage.
+
+    Uses a two-dimensional RBF kernel to allow the noise level to vary
+    smoothly across the input space. The resulting covariance can be
+    marginalized analytically with ExactGP models.
+    """
+
+    def __init__(
+        self,
+        kernel: gpytorch.kernels.Kernel | None = None,
+        *,
+        lengthscale_prior: gpytorch.priors.Prior | None = None,
+        outputscale_prior: gpytorch.priors.Prior | None = None,
+    ):
+        super().__init__()
+        if kernel is None:
+            if lengthscale_prior is None:
+                lengthscale_prior = SmoothedBoxPrior(0.05, 0.5)
+            if outputscale_prior is None:
+                outputscale_prior = SmoothedBoxPrior(1e-6, 0.25)
+            base_kernel = RBFKernel(ard_num_dims=2, lengthscale_prior=lengthscale_prior)
+            kernel = ScaleKernel(base_kernel, outputscale_prior=outputscale_prior)
+        self.covar_module = kernel
+
+    def forward(self, x, shape=None, noise=None, **kwargs):
+        return self.covar_module(x)
+
+
+class GaussianProcessGaussianLikelihood(_GaussianLikelihoodBase):
+    """Gaussian likelihood with a Gaussian process noise covariance."""
+
+    def __init__(
+        self,
+        kernel: gpytorch.kernels.Kernel | None = None,
+        *,
+        lengthscale_prior: gpytorch.priors.Prior | None = None,
+        outputscale_prior: gpytorch.priors.Prior | None = None,
+    ):
+        noise_covar = GaussianProcessNoise(
+            kernel=kernel,
+            lengthscale_prior=lengthscale_prior,
+            outputscale_prior=outputscale_prior,
+        )
+        super().__init__(noise_covar=noise_covar)
+
+    @property
+    def covar_module(self):
+        return self.noise_covar.covar_module

--- a/src/rating_gp/models/priors.py
+++ b/src/rating_gp/models/priors.py
@@ -1,0 +1,71 @@
+"""Custom prior distributions for rating_gp models."""
+
+import math
+
+import torch
+from torch.distributions import Distribution, constraints
+from torch.nn import Module as TModule
+
+from gpytorch.priors import Prior
+from gpytorch.priors.utils import _bufferize_attributes
+
+
+class _Horseshoe(Distribution):
+    """Half-horseshoe distribution.
+
+    This distribution has support on the positive reals and provides strong
+    shrinkage around zero with very heavy tails, making it useful as a prior for
+    scale parameters that may occasionally take on extremely large values.
+
+    The probability density function is
+
+    .. math::
+
+        f(x \mid s) = \frac{2}{\pi s} \log\left(1 + \frac{s^2}{x^2}\right),
+
+    where ``s`` is a positive scale parameter and ``x > 0``.
+    """
+
+    arg_constraints = {"scale": constraints.positive}
+    support = constraints.positive
+
+    def __init__(self, scale, validate_args=False):
+        self.scale = torch.as_tensor(scale)
+        batch_shape = self.scale.shape
+        super().__init__(batch_shape=batch_shape, validate_args=validate_args)
+
+    def sample(self, sample_shape=torch.Size()):  # pragma: no cover - sampling is stochastic
+        shape = sample_shape + self.batch_shape
+        lam = torch.distributions.HalfCauchy(torch.ones_like(self.scale)).rsample(shape)
+        tau = torch.distributions.HalfCauchy(self.scale).rsample(shape)
+        z = torch.abs(torch.randn(shape, dtype=self.scale.dtype, device=self.scale.device))
+        return tau * lam * z
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        scale = self.scale
+        return (
+            math.log(2.0)
+            - math.log(math.pi)
+            - torch.log(scale)
+            + torch.log(torch.log1p((scale / value) ** 2))
+        )
+
+
+class HorseshoePrior(Prior, _Horseshoe):
+    """Horseshoe prior for non-negative parameters."""
+
+    def __init__(self, scale=1.0, validate_args=None, transform=None):
+        TModule.__init__(self)
+        _Horseshoe.__init__(self, scale=scale, validate_args=validate_args)
+        _bufferize_attributes(self, ("scale",))
+        self._transform = transform
+
+    def expand(self, batch_shape):
+        batch_shape = torch.Size(batch_shape)
+        return HorseshoePrior(self.scale.expand(batch_shape))
+
+
+__all__ = ["HorseshoePrior"]
+

--- a/tests/test_gaussian_process_noise.py
+++ b/tests/test_gaussian_process_noise.py
@@ -29,6 +29,6 @@ def test_gaussian_process_gaussian_likelihood_has_priors():
     assert isinstance(covar.outputscale_prior, gpytorch.priors.SmoothedBoxPrior)
     # priors should keep lengthscale and outputscale within reasonable bounds
     assert float(base.lengthscale_prior.a) > 0.0
-    assert float(base.lengthscale_prior.b) <= 0.5
+    assert float(base.lengthscale_prior.b) <= 0.25
     assert float(covar.outputscale_prior.a) > 0.0
-    assert float(covar.outputscale_prior.b) <= 0.25
+    assert float(covar.outputscale_prior.b) <= 4.0

--- a/tests/test_gaussian_process_noise.py
+++ b/tests/test_gaussian_process_noise.py
@@ -1,0 +1,34 @@
+import torch
+import gpytorch
+import pytest
+
+from rating_gp.models.gpytorch import ExactGPModel
+from rating_gp.models.noise import GaussianProcessGaussianLikelihood
+
+
+def test_gaussian_process_gaussian_likelihood_requires_inputs():
+    train_x = torch.rand(5, 2)
+    train_y = torch.randn(5)
+    likelihood = GaussianProcessGaussianLikelihood()
+    model = ExactGPModel(train_x, train_y, likelihood)
+    mll = gpytorch.mlls.ExactMarginalLogLikelihood(likelihood, model)
+    output = model(train_x)
+
+    with pytest.raises(TypeError):
+        mll(output, train_y)
+
+    # Should succeed when inputs are provided
+    mll(output, train_y, train_x)
+
+
+def test_gaussian_process_gaussian_likelihood_has_priors():
+    likelihood = GaussianProcessGaussianLikelihood()
+    covar = likelihood.covar_module
+    base = covar.base_kernel
+    assert isinstance(base.lengthscale_prior, gpytorch.priors.SmoothedBoxPrior)
+    assert isinstance(covar.outputscale_prior, gpytorch.priors.SmoothedBoxPrior)
+    # priors should keep lengthscale and outputscale within reasonable bounds
+    assert float(base.lengthscale_prior.a) > 0.0
+    assert float(base.lengthscale_prior.b) <= 0.5
+    assert float(covar.outputscale_prior.a) > 0.0
+    assert float(covar.outputscale_prior.b) <= 0.25

--- a/tests/test_rating_gp.py
+++ b/tests/test_rating_gp.py
@@ -6,6 +6,8 @@ from matplotlib.axes import Axes
 from matplotlib.colorbar import Colorbar
 
 from rating_gp.models.gpytorch import RatingGPMarginalGPyTorch as RatingGP
+from rating_gp.models.base import ModelConfig
+from rating_gp.models.noise import HeteroskedasticGaussianLikelihood
 
 
 @pytest.fixture
@@ -31,12 +33,13 @@ def training_data():
 
 def test_rating_gp(training_data):
 
-    model = RatingGP()
+    model = RatingGP(model_config=ModelConfig(noise_model="heteroskedastic"))
     model.fit(target=training_data['discharge'],
               covariates=training_data[['stage']],
               target_unc=training_data['discharge_unc'],
               iterations=10)
     assert model.is_fitted
+    assert isinstance(model.likelihood, HeteroskedasticGaussianLikelihood)
 
     assert isinstance(model.plot_stage(), Axes)
     assert isinstance(model.plot_discharge(), Axes)
@@ -50,7 +53,7 @@ def test_rating_gp(training_data):
 
 
 def test_rating_gp_with_monotonic_penalty(training_data):
-    model = RatingGP()
+    model = RatingGP(model_config=ModelConfig(noise_model="heteroskedastic"))
     # Run a short training with the monotonicity penalty enabled to ensure it integrates
     model.fit(
         target=training_data['discharge'],

--- a/tests/test_rating_gp.py
+++ b/tests/test_rating_gp.py
@@ -5,7 +5,6 @@ import xarray as xr
 from matplotlib.axes import Axes
 from matplotlib.colorbar import Colorbar
 
-from rating_gp.providers import usgs
 from rating_gp.models.gpytorch import RatingGPMarginalGPyTorch as RatingGP
 
 
@@ -64,3 +63,5 @@ def test_rating_gp_with_monotonic_penalty(training_data):
         grid_size=16,
     )
     assert model.is_fitted
+
+

--- a/tests/test_rating_gp.py
+++ b/tests/test_rating_gp.py
@@ -7,7 +7,10 @@ from matplotlib.colorbar import Colorbar
 
 from rating_gp.models.gpytorch import RatingGPMarginalGPyTorch as RatingGP
 from rating_gp.models.base import ModelConfig
-from rating_gp.models.noise import HeteroskedasticGaussianLikelihood
+from rating_gp.models.noise import (
+    HeteroskedasticGaussianLikelihood,
+    GaussianProcessGaussianLikelihood,
+)
 
 
 @pytest.fixture
@@ -33,13 +36,13 @@ def training_data():
 
 def test_rating_gp(training_data):
 
-    model = RatingGP(model_config=ModelConfig(noise_model="heteroskedastic"))
+    model = RatingGP(model_config=ModelConfig())
     model.fit(target=training_data['discharge'],
               covariates=training_data[['stage']],
               target_unc=training_data['discharge_unc'],
               iterations=10)
     assert model.is_fitted
-    assert isinstance(model.likelihood, HeteroskedasticGaussianLikelihood)
+    assert isinstance(model.likelihood, GaussianProcessGaussianLikelihood)
 
     assert isinstance(model.plot_stage(), Axes)
     assert isinstance(model.plot_discharge(), Axes)
@@ -66,5 +69,6 @@ def test_rating_gp_with_monotonic_penalty(training_data):
         grid_size=16,
     )
     assert model.is_fitted
+    assert isinstance(model.likelihood, HeteroskedasticGaussianLikelihood)
 
 


### PR DESCRIPTION
## Summary
- bound GP noise kernel lengthscale and outputscale with SmoothedBoxPrior defaults so the noise process can't mimic the signal
- expose optional priors through GaussianProcessGaussianLikelihood
- test that GP noise likelihood registers bounded priors

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b1023c64832da1c03e7c96a207bf