### PR TITLE
fix(pipeline): mark custom transformers as fitted for sklearn 1.8.0

### DIFF
--- a/src/discontinuum/pipeline.py
+++ b/src/discontinuum/pipeline.py
@@ -74,6 +74,7 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
         pass
 
     def fit(self, X, y=None):
+        self.is_fitted_ = True
         return self
 
 

--- a/src/discontinuum/pipeline.py
+++ b/src/discontinuum/pipeline.py
@@ -77,6 +77,9 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
         self.is_fitted_ = True
         return self
 
+    def __sklearn_is_fitted__(self):
+        return getattr(self, "is_fitted_", False)
+
 
 class ClipTransformer(BaseTransformer):
     """Clip a variable."""
@@ -126,6 +129,7 @@ class UnitScaler(BaseTransformer):
     def fit(self, X, y=None):
         self.min_ = X.min()
         self.max_ = X.max()
+        super().fit(X, y)
         return self
     
     def transform(self, X):
@@ -150,6 +154,7 @@ class StandardScaler(BaseTransformer):
             self.mean_ = X.mean(axis=0)
         if self.with_std:
             self.scale_ = X.std(axis=0)
+        super().fit(X, y)
         return self
 
     def transform(self, X):

--- a/src/discontinuum/tests/test_pipeline.py
+++ b/src/discontinuum/tests/test_pipeline.py
@@ -1,5 +1,6 @@
 import numpy as np
-from discontinuum.pipeline import TimeTransformer
+import xarray as xr
+from discontinuum.pipeline import LogErrorPipeline, TimeTransformer
 
 
 def test_time_transform():
@@ -26,3 +27,15 @@ def test_time_transform():
 
     # Check if the inverse transformed data matches the original data
     np.testing.assert_equal(data, inverse_transformed_data)
+
+
+def test_log_error_pipeline_transform_after_fit():
+    """Ensure LogErrorPipeline is recognized as fitted by sklearn."""
+    x = xr.DataArray(
+        np.array([1.1, 1.2, 1.4], dtype=float),
+        dims=("time",),
+        name="discharge_unc",
+    )
+    pipeline = LogErrorPipeline().fit(x)
+    transformed = pipeline.transform(x)
+    assert transformed.shape == (x.shape[0], 1)


### PR DESCRIPTION
Fixes compatibility with `sklearn` v1.8.0

- Set BaseTransformer.fit() to populate a fitted attribute (is_fitted_).
- Prevent NotFittedError when Pipeline.transform() checks fitted state on stateless final steps (e.g., ClipTransformer in LogErrorPipeline).
- Add regression test covering LogErrorPipeline.fit(...).transform(...).
- Unblocks rating_gp training with target_unc in notebook and tests.