### PR TITLE
Migrate to waterdata API and clean up codebase

### DIFF
--- a/docs/source/notebooks/loadest-gp-demo.ipynb
+++ b/docs/source/notebooks/loadest-gp-demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "4468d2cc-8303-40d7-8821-8b85c8c21e3e",
+   "id": "0",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -22,7 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "272692db-c31c-4f2d-9a66-bb904a85d3ce",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c139f8d5-ae66-4e7e-9c20-8a58a704a8dc",
+   "id": "2",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -54,7 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "102a05a4-2f32-4acc-ad3e-c3505b1e4846",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,12 +71,12 @@
     "end_date = \"2011-09-30\"\n",
     "\n",
     "characteristic = 'Inorganic nitrogen (nitrate and nitrite)'\n",
-    "fraction = 'Dissolved'"
+    "fraction = 'Filtered field and/or lab'"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b013affa-c9ac-4015-b2a0-13b082be2ae8",
+   "id": "4",
    "metadata": {},
    "source": [
     "First, download the data. In `discontinuum`, the convention is to download directly using `providers`, which wrap a data provider's web-service and perform some initial formatting and metadata construction, then return the result as an `xarray.Dataset`. Here, we use the `usgs` provider. If you need data from another source, create a `provider` and ensure the output matches that of the `usgs` provider. We'll download some daily streamflow data to use as our model's input, and some concentration samples as our target. "
@@ -85,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4425fc1-a193-4f51-accc-5048d7805901",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "036dc34e-da51-4a1a-a2c0-b63a06a01f8f",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc0b8f59-58b0-47a6-86d0-d407c599e104",
+   "id": "7",
    "metadata": {},
    "source": [
     "Next, prepare the training data by performing an inner join of the target and covariates."
@@ -125,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f89df570-5a21-4438-9091-8c10d69bfffe",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3bf2188c-8e1b-401e-a7e2-b1d630621202",
+   "id": "9",
    "metadata": {},
    "source": [
     "Now, we're ready to fit the model. Depending on your hardware, this can take seconds to several minutes. The first fit will also compile the model, which takes longer. After running it once, try running the cell again and note the difference in wall time."
@@ -147,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60d0eef3-1f31-4950-897b-11713e17a284",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f04bfb6-b9d1-4c35-aa1d-4f073b7c494c",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7557d315-60a0-404a-99c0-fef59f69c062",
+   "id": "12",
    "metadata": {},
    "source": [
     "Like WRTDS, we can also plot the variable space:"
@@ -183,7 +183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52aa71aa-82f5-4f09-8202-683b44bacba4",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +192,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c561ff69-bc37-493b-b414-18dfcbd07d9b",
+   "id": "14",
    "metadata": {},
    "source": [
     "For plotting, we don't need to simulate the full covariance matrix. Instead, we can use its diagonal to compute confidence intervals, but for most other uses, we need to simulate predictions using full covariance, which is slower. Here, we simulate daily concentration during 1980-2010, then we will use those simulations to estimate annual fluxes with uncertainty."
@@ -201,7 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "06fa42a3-2414-445b-9c25-1c7d6af6cf60",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "370f7155-d3b3-452c-bb7c-0a80f60107d5",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +224,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64fb7ba8-c3d7-42a5-aa89-f228774b4608",
+   "id": "17",
    "metadata": {},
    "source": [
     "In practice, we aren't interested in a single simulated timeseries. Rather, we take a large sample of simulated series, then pass them through some function to simulate a probability distribution. For example, if we were interested in some annual value we would pass the simulations through that annual function to estimate a probability distribution. We demonstrate this concept for estimating the annual nutrient flux.\n",
@@ -235,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ebf5a5b8-cedd-4d18-860f-9a0ea392a9b8",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +247,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a563850-1cab-4bfa-b393-e98e3b0aa3cb",
+   "id": "19",
    "metadata": {},
    "source": [
     "In most streams, flow varies substantially from year-to-year, \n",
@@ -272,7 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57176f69-df5a-4b49-93d4-ec11d33aee91",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e718984-c9a5-4c85-af25-4dbe088272c8",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adb2afdb-b4b4-4d6b-8429-59f3014fce1b",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,7 +307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae6afc7e-116b-44b7-a0ed-617f219dd3c2",
+   "id": "23",
    "metadata": {},
    "source": [
     "Now, the annual fluxes should be less variable than before, and the trend becomes apparent (depending on your choice of river)."

--- a/docs/source/notebooks/rating-gp-demo.ipynb
+++ b/docs/source/notebooks/rating-gp-demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "4468d2cc-8303-40d7-8821-8b85c8c21e3e",
+   "id": "0",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -21,7 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "272692db-c31c-4f2d-9a66-bb904a85d3ce",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c139f8d5-ae66-4e7e-9c20-8a58a704a8dc",
+   "id": "2",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0aa9360-616e-4ba3-a027-5fecb7cd5f2f",
+   "id": "3",
    "metadata": {},
    "source": [
     "### USGS site 10154200\n",
@@ -65,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "102a05a4-2f32-4acc-ad3e-c3505b1e4846",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f90247a0-d376-4068-aa3a-7fbca417095e",
+   "id": "5",
    "metadata": {},
    "source": [
     "Now that we have selected our site, we need to download the data. In `discontinuum`, the convention is to download directly using `providers`, which wrap a data provider's web-service and perform some initial formatting and metadata construction, then return the result as an `xarray.Dataset`. Here, we use the `usgs` provider. If you need data from another source, create a `provider` and ensure the output matches that of the `usgs` provider. Here, we'll download some instantaneous stage data to use as our model's input, and some discharge data as our target. "
@@ -87,7 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61a1093e-31cd-4412-b549-ede2a7e4270c",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09ea017d-dbc3-4453-924a-e04f8f4d0c9d",
+   "id": "7",
    "metadata": {},
    "source": [
     "With the training data, we're now ready to fit a model to the site. Depending on your hardware, this should take about 10s."
@@ -109,7 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60d0eef3-1f31-4950-897b-11713e17a284",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33170d73-2154-4fb2-8cb1-5deba1dfc96f",
+   "id": "9",
    "metadata": {},
    "source": [
     "With the model fit, we can generate some nice plots of an observed rating curve and time series of both stage and discharge."
@@ -137,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c176dcb2-1b1b-490f-884c-bf8faf88fd5e",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +151,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc40a9c0-8d93-4bc9-9d50-0a73ae93552b",
+   "id": "11",
    "metadata": {},
    "source": [
     "One major advantage of `rating-gp` is that the resulting model can be used to make predictions of a rating curve at any moment in time. To see how well our model can predict a rating curve across time, let's plot the rating curves at an interval of every 5 years at the start of a water year (i.e., October 1st). This way we can see how well the model accounts for any shift in the rating with time."
@@ -160,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "865133e2-35d0-4126-a02f-38a0c9d5937b",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a36ffc1-0f58-496f-80a8-af08f466cd3b",
+   "id": "13",
    "metadata": {},
    "source": [
     "Nice! The shifts with time are clearly predicted by the model. These results are are promising for `rating-gp` to be able to model shift in rating curves effectively."
@@ -185,7 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5e199fe6-721e-412b-8d02-d53b0096d87a",
+   "id": "14",
    "metadata": {},
    "source": [
     "### Multi-site Example\n",
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b6d25c5f-1adb-4454-8573-c794431b1939",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1cdd55d5-ea2a-4ed5-a7e4-f674be4367e6",
+   "id": "16",
    "metadata": {},
    "source": [
     "Now that we have our sites, we need to download the data using the USGS `provider`."
@@ -217,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eac5bb44-e5ac-4e8b-97b2-ca6a7768b2f2",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37b2ed07-f49b-4e87-8853-f42df1ded755",
+   "id": "18",
    "metadata": {},
    "source": [
     "With the training data, we're now ready to fit a model to each site. Depending on your hardware, this should take about 10-20s for each site."
@@ -237,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c8acf93b-2fb6-4f4f-bf81-5be77853b39e",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +256,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd5c19a3-b269-4862-9bbc-16f421edfeec",
+   "id": "20",
    "metadata": {},
    "source": [
     "Now that we have our models fit, let's plot all of the rating curves in time as we did above. We will again predict each rating at an interval of every 5 years at the start of a water year (i.e., October 1st) in 1990."
@@ -265,7 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "07bc259e-5517-496e-b342-7149ca753811",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f703529-513a-4e17-8061-c240b25a9c4b",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
   "ruff",
   "pytest-cov[all]",
   "requests_mock",
-  "dataretrieval",
+  "dataretrieval > 1.1.0",
 ]
 
 doc = [
@@ -62,11 +62,11 @@ pymc = [
 # models
 
 loadest_gp = [
-  "dataretrieval",
+  "dataretrieval > 1.1.0",
 ]
 
 rating_gp = [
-  "dataretrieval",
+  "dataretrieval > 1.1.0",
 ]
 
 [project.urls]

--- a/src/discontinuum/data_manager.py
+++ b/src/discontinuum/data_manager.py
@@ -104,13 +104,13 @@ class DataManager:
         return Dataset(covariates)
 
     @cached_property
-    def y(self, dtype="float32") -> ArrayLike:
+    def y(self) -> ArrayLike:
         """Convenience function for DataManager.target.transform"""
         return self.target_pipeline.transform(self.data.target).flatten()
 
     @cached_property
-    def y_unc(self, dtype="float32") -> ArrayLike:
-        """Convenience function for DataManager.target.transform"""
+    def y_unc(self) -> ArrayLike:
+        """Convenience function for DataManager.error_pipeline.transform"""
         return self.error_pipeline.transform(self.data.target_unc).flatten()
 
     @cached_property

--- a/src/discontinuum/engines/gpytorch.py
+++ b/src/discontinuum/engines/gpytorch.py
@@ -8,7 +8,6 @@ import gpytorch
 import numpy as np
 import torch
 import tqdm
-import xarray as xr
 from xarray import DataArray, Dataset
 
 from discontinuum.engines.base import BaseModel, is_fitted
@@ -16,7 +15,6 @@ from discontinuum.engines.base import BaseModel, is_fitted
 if TYPE_CHECKING:
     from os import PathLike
     from typing import IO, Union
-    from numpy.typing import ArrayLike
     from typing import Dict, Optional, Tuple, Callable
     from xarray import Dataset
 

--- a/src/discontinuum/pipeline.py
+++ b/src/discontinuum/pipeline.py
@@ -74,6 +74,7 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
         pass
 
     def fit(self, X, y=None):
+        self.is_fitted_ = True
         return self
 
 
@@ -120,11 +121,12 @@ class SquareTransformer(OneToOneFeatureMixin, BaseTransformer):
 class UnitScaler(BaseTransformer):
     """Rescale a variable to have a minimum of 0 and a maximum of 1."""
     def __init__(self, zero_value=0):
-        self.zero = zero_value    
+        self.zero = zero_value
 
     def fit(self, X, y=None):
         self.min_ = X.min()
         self.max_ = X.max()
+        self.is_fitted_ = True
         return self
     
     def transform(self, X):
@@ -149,6 +151,7 @@ class StandardScaler(BaseTransformer):
             self.mean_ = X.mean(axis=0)
         if self.with_std:
             self.scale_ = X.std(axis=0)
+        self.is_fitted_ = True
         return self
 
     def transform(self, X):
@@ -178,7 +181,7 @@ class TimeTransformer(BaseTransformer):
 class MetadataManager(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
     def __init__(self):
         """Store xarray metadata (attrs)."""
-        self.attrs = None
+        pass
 
     def fit(self, X, y=None):
         """Store metadata from a xarray DataArray.
@@ -190,9 +193,9 @@ class MetadataManager(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         y : None
             Ignored.
         """
-        self.attrs = X.attrs
-        self.name = X.name
-        self.dims = X.dims
+        self.attrs_ = X.attrs
+        self.name_ = X.name
+        self.dims_ = X.dims
 
         return self
 
@@ -222,9 +225,9 @@ class MetadataManager(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         """
         return DataArray(
             X.squeeze(),
-            attrs=self.attrs,
-            name=self.name,
-            dims=self.dims,
+            attrs=self.attrs_,
+            name=self.name_,
+            dims=self.dims_,
         )
 
 

--- a/src/discontinuum/plot.py
+++ b/src/discontinuum/plot.py
@@ -5,14 +5,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
-import numpy as np
 from discontinuum.engines.base import is_fitted
-from scipy.stats import norm
 from xarray import DataArray
-from xarray.plot.utils import label_from_attrs
 
 if TYPE_CHECKING:
-    from typing import Dict, Optional
+    from typing import Optional
 
     from matplotlib.pyplot import Axes
     from xarray import Dataset

--- a/src/loadest_gp/__init__.py
+++ b/src/loadest_gp/__init__.py
@@ -1,34 +1,17 @@
-import sys
 import warnings
 
-__all_gpytorch__ = [
-    # Sub-packages in models.gpytorch
-    "LoadestGPMarginalGPyTorch",
-]
+from .models.gpytorch import LoadestGPMarginalGPyTorch
 
-__all_pymc__ = [
-    # PyMC sub-packages in models.pymc
-    "LoadestGPMarginalPyMC",
-]
+__all__ = ["LoadestGPMarginalGPyTorch"]
 
-for name in __all_gpytorch__:
-    exec(f"from .models.gpytorch import {name}")
-
-__all__ = __all_gpytorch__.copy()
-
-
-# check if pymc is installed, then import the sub-packages
 try:
-    import pymc
-    __all__.extend(__all_pymc__)
+    import pymc  # noqa: F401
+    from .models.pymc import LoadestGPMarginalPyMC  # noqa: F401
 
-    for name in __all_pymc__:
-        exec(f"from .models.pymc import {name}")
-
+    __all__.append("LoadestGPMarginalPyMC")
 except ModuleNotFoundError:
-    # if pymc is not installed, raise a warning
     warnings.warn(
-        f"`pymc` is not installed: {', '.join(__all_pymc__)}"
-        " will not be available.",
+        "`pymc` is not installed: LoadestGPMarginalPyMC will not be available.",
         UserWarning,
+        stacklevel=2,
     )

--- a/src/loadest_gp/models/gpytorch.py
+++ b/src/loadest_gp/models/gpytorch.py
@@ -61,7 +61,7 @@ class LoadestGPMarginalGPyTorch(
 
 class ExactGPModel(gpytorch.models.ExactGP):
     def __init__(self, train_x, train_y, likelihood):
-        super(ExactGPModel, self).__init__(train_x, train_y, likelihood)
+        super().__init__(train_x, train_y, likelihood)
 
         n_d = train_x.shape[1]  # number of dimensions
         self.dims = np.arange(n_d)

--- a/src/loadest_gp/plot.py
+++ b/src/loadest_gp/plot.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numpy as np
 
 from discontinuum.engines.base import is_fitted
 from discontinuum.plot import BasePlotMixin
-from xarray.plot.utils import label_from_attrs
 
 if TYPE_CHECKING:
     from typing import Dict, Optional

--- a/src/loadest_gp/providers/usgs.py
+++ b/src/loadest_gp/providers/usgs.py
@@ -26,23 +26,11 @@ class USGSParameter:
     standard_name: str
     long_name: Optional[str] = ""
     units: Optional[str] = ""
-    suffix: Optional[str] = ""
     conversion: Optional[float] = 1.0
 
     @property
-    def ppcode(self):
-        """
-        Return the parameter code with a 'p' prefix, which is used by the QWData
-        service.
-
-        """
-        return "p" + self.pcode
-
-    @property
     def name(self):
-        """
-        Alias for standard_name.
-        """
+        """Alias for standard_name."""
         return self.standard_name
 
 
@@ -51,7 +39,6 @@ USGSFlow = USGSParameter(
     standard_name="flow",
     long_name="Streamflow",
     units="cubic meters per second",
-    suffix="_Mean",
     conversion=0.0283168,
 )
 
@@ -176,11 +163,6 @@ def get_daily(
     )
 
     return format_daily(df, site, params)
-
-
-def format_wqp_date(date: str) -> str:
-    """Reformat date from 'YYYY-MM-DD' to 'MM-DD-YYYY'."""
-    return "-".join(date.split("-")[1:] + [date.split("-")[0]])
 
 
 def format_daily(

--- a/src/loadest_gp/providers/usgs.py
+++ b/src/loadest_gp/providers/usgs.py
@@ -8,11 +8,10 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 import xarray as xr
-from dataretrieval import nwis, wqp
+from dataretrieval import waterdata
 from discontinuum.providers.base import MetaData
 
 if TYPE_CHECKING:
-    # from pandas import DataFrame
     from typing import Dict, List, Optional, Union
 
     from xarray import Dataset
@@ -64,8 +63,8 @@ def get_parameters(
 
     Parameters
     ----------
-    pcodes : List[str]
-        List of USGS parameter codes.
+    pcodes : Dict[str, str]
+        Mapping of standard names to USGS parameter codes.
 
     Returns
     -------
@@ -73,19 +72,13 @@ def get_parameters(
         List of USGS parameters.
     """
     lookup_name = {value: key for key, value in pcodes.items()}
-    pcode_list = [v for _, v in pcodes.items()]
 
-    df, _ = nwis.get_pmcodes(pcode_list)
-
-    # convert to USGSParameter
     params = []
-    for _, row in df.iterrows():
+    for pcode, name in lookup_name.items():
         params.append(
             USGSParameter(
-                pcode=row["parameter_cd"],
-                standard_name=lookup_name[row["parameter_cd"]],
-                long_name=row["SRSName"],
-                units=row["parm_unit"],
+                pcode=pcode,
+                standard_name=name,
             )
         )
 
@@ -96,26 +89,42 @@ def get_parameters(
 
 
 def get_metadata(site: str) -> MetaData:
-    """Get site metadata from the USGS NWIS API.
+    """Get site metadata from the USGS Water Data API.
 
     Parameters
     ----------
     site : str
-        USGS site number.
+        USGS site number (e.g., '03339000' or 'USGS-03339000').
 
     Returns
     -------
-    pandas.DataFrame
-        Dataframe with the site information.
+    MetaData
+        Dataclass with the site information.
     """
-    df, _ = nwis.get_info(sites=site)
+    if not site.startswith("USGS-"):
+        site = "USGS-" + site
+
+    df, _ = waterdata.get_monitoring_locations(
+        monitoring_location_id=[site],
+    )
     row = df.iloc[0]
 
+    # geometry is [lon, lat] when geopandas is not installed
+    geometry = row["geometry"]
+    if isinstance(geometry, (list, tuple)):
+        longitude, latitude = geometry[0], geometry[1]
+    elif hasattr(geometry, "x") and hasattr(geometry, "y"):
+        longitude, latitude = geometry.x, geometry.y
+    else:
+        longitude, latitude = None, None
+
+    site_no = row.get("monitoring_location_number", site)
+
     return MetaData(
-        id=row["site_no"],
-        name=row["station_nm"],
-        latitude=row["dec_lat_va"],
-        longitude=row["dec_long_va"],
+        id=site_no,
+        name=row["monitoring_location_name"],
+        latitude=latitude,
+        longitude=longitude,
     )
 
 
@@ -127,7 +136,7 @@ def get_daily(
     params: Union[List[USGSParameter], USGSParameter] = USGSFlow,
     **kwargs,
 ) -> Dataset:
-    """Get daily data from the USGS NWIS API.
+    """Get daily data from the USGS Water Data API.
 
     Parameters
     ----------
@@ -140,7 +149,7 @@ def get_daily(
     params : List[USGSParameter], optional
         List of parameters to retrieve. The default is flow only `[USGSFlow]`.
     kwargs : Dict
-        Additional keyword arguments to pass to the NWIS API.
+        Additional keyword arguments to pass to the API.
 
     Returns
     -------
@@ -152,15 +161,21 @@ def get_daily(
 
     pcodes = [param.pcode for param in params]
 
-    df, _ = nwis.get_dv(
-        sites=site,
-        start=start_date,
-        end=end_date,
-        parameterCd=pcodes,
-        **kwargs,
-        )
+    if not site.startswith("USGS-"):
+        monitoring_location_id = "USGS-" + site
+    else:
+        monitoring_location_id = site
 
-    return format_nwis_daily(df, site, params)
+    time_range = f"{start_date}/{end_date}"
+
+    df, _ = waterdata.get_daily(
+        monitoring_location_id=monitoring_location_id,
+        parameter_code=pcodes,
+        time=time_range,
+        **kwargs,
+    )
+
+    return format_daily(df, site, params)
 
 
 def format_wqp_date(date: str) -> str:
@@ -168,18 +183,18 @@ def format_wqp_date(date: str) -> str:
     return "-".join(date.split("-")[1:] + [date.split("-")[0]])
 
 
-def format_nwis_daily(
+def format_daily(
         df: DataFrame,
         site_id: Optional[str] = None,
         params: Union[List[USGSParameter], USGSParameter] = [USGSFlow],
 ) -> Dataset:
     """
-    Format results of dataretrieval.nwis.get_dv.
+    Format results of waterdata.get_daily.
 
     Parameters
     ----------
     df : DataFrame
-        Dataframe returned from dataretrieval.nwis.get_dv.
+        Dataframe returned from waterdata.get_daily.
     site_id : str, optional
         USGS site number for populating metadata. The default is None.
     params : List[USGSParameter], optional
@@ -188,30 +203,42 @@ def format_nwis_daily(
     if not isinstance(params, list):
         params = [params]
 
-    df = df.copy()
-    # rename columns
-    df = df.rename(
-        columns={
-            param.pcode + param.suffix: param.name for param in params}
-    )
-    # drop columns
-    df = df[[param.name for param in params]]
-    # remove timezone for xarray compatibility
-    df.index = df.index.tz_localize(None)
+    # The waterdata API returns a long-format DataFrame with columns:
+    # time, value, parameter_code, etc.
+    # Pivot to wide format with one column per parameter
+    pcode_to_param = {param.pcode: param for param in params}
 
-    ds = xr.Dataset.from_dataframe(df)
-    # rename "datetime" to "time", which is xarray convention
-    ds = ds.rename({"datetime": "time"})
-    # ds["date"] = ds["date"].dt.date
+    # Filter to requested parameter codes
+    df = df[df["parameter_code"].isin(pcode_to_param.keys())].copy()
+
+    # Pivot from long to wide format
+    pivot_df = df.pivot_table(
+        index="time",
+        columns="parameter_code",
+        values="value",
+        aggfunc="first",
+    )
+
+    # Rename columns from pcode to standard name
+    pivot_df = pivot_df.rename(
+        columns={pcode: pcode_to_param[pcode].name for pcode in pivot_df.columns}
+    )
+
+    # Ensure time index is timezone-naive for xarray compatibility
+    if hasattr(pivot_df.index, "tz") and pivot_df.index.tz is not None:
+        pivot_df.index = pivot_df.index.tz_localize(None)
+
+    ds = xr.Dataset.from_dataframe(pivot_df)
 
     # set metadata
     if site_id:
         ds.attrs = get_metadata(site_id).__dict__
 
     for param in params:
-        ds[param.name] = ds[param.name] * param.conversion
-        # xarray metadata assignment must come after all other operations
-        ds[param.name].attrs = param.__dict__
+        if param.name in ds:
+            ds[param.name] = ds[param.name] * param.conversion
+            # xarray metadata assignment must come after all other operations
+            ds[param.name].attrs = param.__dict__
 
     return ds
 
@@ -221,12 +248,12 @@ def format_wqp_samples(
         name: str = "concentration",
         pcode: Optional[str] = None,
 ) -> Dataset:
-    """Format results of dataretrieval.wqp.get_results.
+    """Format results of waterdata.get_samples.
 
     Parameters
     ----------
     df : DataFrame
-        Dataframe returned from dataretrieval.wqp.get_results.
+        Dataframe returned from waterdata.get_samples.
     name : str
         Short name for the parameter. Default is 'concentration'.
     pcode : str
@@ -238,10 +265,10 @@ def format_wqp_samples(
     """
     # create datetime index
     df.index = pd.to_datetime(
-        df["ActivityStartDate"] + " " + df["ActivityStartTime/Time"]
+        df["Activity_StartDate"] + " " + df["Activity_StartTime"]
     )
 
-    df[name] = df["ResultMeasureValue"].astype(float)
+    df[name] = df["Result_Measure"].astype(float)
     df.index.name = "time"
     df.index = df.index.tz_localize(None)
 
@@ -288,57 +315,50 @@ def get_samples(
     characteristic : str
         The name of the parameter to retrieve.
     fraction : str
-        The fraction of the parameter to retrieve. Options are 'Total',
-        'Dissolved', 'Suspended'.
+        The fraction of the parameter to retrieve. Options are
+        'Filtered field and/or lab', 'Unfiltered', etc.
     provider : str
         The data provider. Options are 'NWIS' or 'STORET'.
     name : str
         Short name for the parameter. Default is 'concentration'.
     filter_pcodes : List[str]
-        List of parameter codes to filter the dataset. 
+        List of parameter codes to filter the dataset.
     kwargs : Dict
         Additional keyword arguments to pass to the WQP API.
     """
-    if fraction and fraction not in ["Total", "Dissolved", "Suspended"]:
-        raise ValueError("Fraction must be 'Total', 'Dissolved', 'Suspended'")
-
     if provider not in ["NWIS", "STORET"]:
         raise ValueError("Provider must be 'NWIS' or 'STORET'")
 
     if provider == "NWIS" and not site.startswith("USGS-"):
         site = "USGS-" + site
 
-    # reformat dates from 'YYYY-MM-DD' to 'MM-DD-YYYY'
-    start_date = format_wqp_date(start_date)
-    end_date = format_wqp_date(end_date)
-
-    df, _ = wqp.get_results(
-        siteid=site,
-        startDateLo=start_date,
-        startDateHi=end_date,
-        characteristicName=characteristic,
-        provider=provider,
+    df, _ = waterdata.get_samples(
+        monitoringLocationIdentifier=site,
+        characteristic=characteristic,
+        activityStartDateLower=start_date,
+        activityStartDateUpper=end_date,
         **kwargs,
-        )
+    )
 
     # filter by fraction
     if fraction:
-        df = df[df["ResultSampleFractionText"] == fraction]
+        df = df[df["Result_SampleFraction"] == fraction]
 
     if provider == "NWIS":
         if filter_pcodes:
             # filter df by list of pcodes
-            df = df[df["USGSPCode"].isin(filter_pcodes)]
+            filter_pcodes_int = [int(p) for p in filter_pcodes]
+            df = df[df["USGSpcode"].isin(filter_pcodes_int)]
             pcode = filter_pcodes[0]
 
-        elif len(set(df["USGSPCode"])) != 1:
+        elif len(set(df["USGSpcode"])) != 1:
             raise ValueError("Multiple parameters returned from NWIS.")
 
         else:
             # only one pcode returned, so take the first entry
-            pcode = df["USGSPCode"].iloc[0]
+            pcode = df["USGSpcode"].iloc[0]
 
-        pcode = str(pcode).zfill(5)
+        pcode = str(int(pcode)).zfill(5)
 
     else:
         pcode = None
@@ -347,76 +367,11 @@ def get_samples(
 
     if provider == "NWIS":
         # strip the "USGS-" prefix from the site number
-        site_id = site[5:]
+        site_id = site[5:] if site.startswith("USGS-") else site
         ds.attrs = get_metadata(site_id).__dict__
 
     if provider == "STORET":
         # TODO check for "USGS-" prefix, then get metadata
         pass
-
-    return ds
-
-
-def get_qwdata_samples(
-    site: str,
-    start_date: str,
-    end_date: str,
-    pcode: str,
-    name: str = "concentration",
-) -> Dataset:
-    """Get sample data from the USGS NWIS API.
-
-    WARNING: The QWData service is deprecated and no longer receives data.
-
-    Parameters
-    ----------
-    site : str
-        USGS site number.
-    start_date : str
-        Start date in the format 'yyyy-mm-dd'.
-    end_date : str
-        End date in the format 'yyyy-mm-dd'.
-    pcode : str
-        USGS parameter to retrieve.
-    name : str
-        Short name for the parameter.
-
-    Returns
-    -------
-    pandas.DataFrame
-        Dataframe with the requested sample data.
-    """
-    warnings.warn(
-        "The QWData service is deprecated and no longer receives data.",
-        DeprecationWarning,
-    )
-
-    df, _ = nwis.get_qwdata(
-        sites=site,
-        start=start_date,
-        end=end_date,
-        parameterCd=pcode,
-    )
-    attrs = get_parameters({name: pcode})
-    ppcode = "p" + pcode
-
-    # check if data are strings
-    if df[ppcode].dtype == "O":
-        # remove "<" and ">" from values and convert to float
-        # TODO handle censoring
-        df[ppcode] = df[ppcode].str.extract(r"(\d+.\d+)", expand=False).astype(float)
-
-    df = df.rename(columns={ppcode: name})
-
-    df = df[[name]]
-    # remove timezone for xarray compatibility
-    df.index = df.index.tz_localize(None)
-
-    ds = xr.Dataset.from_dataframe(df)
-    # rename "datetime" to "time", which is xarray convention
-    ds = ds.rename({"datetime": "time"})
-
-    ds.attrs = get_metadata(site).__dict__
-    ds[name].attrs = attrs.__dict__
 
     return ds

--- a/src/loadest_gp/utils.py
+++ b/src/loadest_gp/utils.py
@@ -38,19 +38,22 @@ def concentration_to_flux(
 
     if len(time_delta) != 1:
         warn("Time delta is not constant",
-             stacklevel=UserWarning,)
+             UserWarning,
+             stacklevel=2)
 
     if flow.units != "cubic meters per second":
         warn(
-            "Check that flow is 'cubic meters per second'.",
+            "Check that flow is 'cubic meters per second'. "
             "Set flow.units = 'cubic meters per second' to silence.",
-            stacklevel=UserWarning,
+            UserWarning,
+            stacklevel=2,
             )
 
     if "mg/l" not in concentration.units:
-        warn("Check that concentration is in 'mg/l'.",
+        warn("Check that concentration is in 'mg/l'. "
              "Set concentration.units = 'mg/l' to silence.",
-             stacklevel=UserWarning,
+             UserWarning,
+             stacklevel=2,
              )
 
     flux = concentration * flow * time_delta * mg_l_to_kg_m3

--- a/src/rating_gp/models/gpytorch.py
+++ b/src/rating_gp/models/gpytorch.py
@@ -6,15 +6,12 @@ from discontinuum.engines.gpytorch import MarginalGPyTorch, NoOpMean
 
 from gpytorch.kernels import (
     MaternKernel,
-    RBFKernel,
-    RQKernel,
     ScaleKernel,
     PeriodicKernel,
 )
 from gpytorch.priors import (
     GammaPrior,
     HalfNormalPrior,
-    HalfCauchyPrior,
     NormalPrior,
 )
 
@@ -31,7 +28,7 @@ class PowerLawTransform(torch.nn.Module):
     """
     """
     def __init__(self):
-        super(PowerLawTransform, self).__init__()
+        super().__init__()
         self.a = torch.nn.Parameter(torch.randn(1))
         # initialize b according to Manning's equation (refer to clamp)
         # Use proper parameter initialization to maintain gradient flow
@@ -50,12 +47,9 @@ class RatingGPMarginalGPyTorch(
     # comes last b/c it conflics with Mixin
     MarginalGPyTorch,
 ):
-    """
-    Gaussian Process implementation of the LOAD ESTimation (LOADEST) model
+    """Gaussian Process model for stage-discharge rating curves.
 
-    This model currrently uses the marginal likelihood implementation, which is
-    fast but does not account for censored data. Censored data require a slower
-    latent variable implementation.
+    Uses the marginal likelihood implementation for fast fitting.
     """
     def __init__(
             self,
@@ -203,7 +197,7 @@ class RatingGPMarginalGPyTorch(
 
 class ExactGPModel(gpytorch.models.ExactGP):
     def __init__(self, train_x, train_y, likelihood):
-        super(ExactGPModel, self).__init__(train_x, train_y, likelihood)
+        super().__init__(train_x, train_y, likelihood)
 
         n_d = train_x.shape[1]  # number of dimensions
         assert n_d == 2, "Only two dimensions supported"

--- a/src/rating_gp/models/gpytorch.py
+++ b/src/rating_gp/models/gpytorch.py
@@ -164,13 +164,21 @@ class RatingGPMarginalGPyTorch(
             try:
                 with gpytorch.settings.fast_pred_var():
                     mean = self.likelihood(self.model(x_grid)).mean
+
+                    # Use finite differences for the stage derivative to avoid
+                    # second-order derivatives through torch.cdist in the kernel,
+                    # which does not support higher-order autograd.
+                    fd_eps = 1e-3
+                    x_grid_plus = x_grid.clone()
+                    x_grid_plus[:, stage_dim] = x_grid[:, stage_dim] + fd_eps
+                    mean_plus = self.likelihood(self.model(x_grid_plus)).mean
             finally:
                 if was_model_training:
                     self.model.train()
                 if was_likelihood_training:
                     self.likelihood.train()
 
-            d_mean_d_stage = torch.autograd.grad(mean.sum(), stage_grid, create_graph=True)[0]
+            d_mean_d_stage = (mean_plus - mean) / fd_eps
             neg = torch.clamp(-d_mean_d_stage, min=0.0)
             pen = neg.mean()
             if monotonic_penalty_interval > 1:

--- a/src/rating_gp/models/kernels.py
+++ b/src/rating_gp/models/kernels.py
@@ -1,16 +1,14 @@
 import gpytorch
 import numpy as np
 import torch
-import torch.nn as nn
-import torch.nn.functional as F
 
-from linear_operator.operators import MatmulLinearOperator, to_dense
+from linear_operator.operators import MatmulLinearOperator
 
 
 class TanhWarp(torch.nn.Module):
 
     def __init__(self):
-        super(TanhWarp, self).__init__()
+        super().__init__()
         self.a = torch.nn.Parameter(torch.rand(1))
         self.b = torch.nn.Parameter(torch.rand(1))
         self.c = torch.nn.Parameter(torch.rand(1))
@@ -25,7 +23,7 @@ class LogWarp(torch.nn.Module):
     Note: good smoother
     """
     def __init__(self):
-        super(LogWarp, self).__init__()
+        super().__init__()
         self.a = torch.nn.Parameter(torch.rand(1))
 
     def forward(self, x):
@@ -259,35 +257,29 @@ class SigmoidKernel(gpytorch.kernels.Kernel):
     """
     def __init__(
         self,
-        # a_prior=None,
-        # a_constraint=None,
         b_constraint,
         b_prior=None,
-        #b_constraint=gpytorch.constraints.Positive(),
         **kwargs,
         ):
         """Initialize the kernel
 
         Parameters
         ----------
-        b_prior : Prior
-            The prior to impose on `b`.
         b_constraint : Constraint
-            The constraint to impose on `b`
+            The constraint to impose on `b` (the switchpoint location).
+        b_prior : Prior, optional
+            The prior to impose on `b`.
         """
         super().__init__(**kwargs)
 
+        # Fixed sigmoid sharpness (learnable `a` causes numerical instabilities)
         self.a = 20
-        # self.a = torch.nn.Parameter(torch.ones(*self.batch_shape, 1, 1) * 40)
-        # self.register_parameter(
-        #     name='raw_a',
-        #     parameter=self.a)
-        
-        # initialize raw_b parameter such that b starts within [l, u]
+
+        # Initialize raw_b within the constraint bounds
         u = b_constraint.upper_bound
         l = b_constraint.lower_bound
         init_b = l + torch.rand((*self.batch_shape, 1, 1)) * (u - l)
-        # register raw_b parameter
+
         self.register_parameter(
             name='raw_b',
             parameter=torch.nn.Parameter(torch.zeros((*self.batch_shape, 1, 1)))
@@ -295,50 +287,17 @@ class SigmoidKernel(gpytorch.kernels.Kernel):
 
         b_prior = gpytorch.priors.NormalPrior(0, 1)
 
-        #self.register_prior(
-        #    "b_prior",
-        #    gpytorch.priors.NormalPrior(0, 1),
-        #    lambda module: module.b,
-        #)
-
-        # register the constraints
-        # if a_constraint is None:
-        #     a_constraint = gpytorch.constraints.Positive()
-        # self.register_constraint("raw_a", a_constraint)
         if b_constraint is not None:
             self.register_constraint("raw_b", b_constraint)
-        # set initial value using inverse transform of the constraint
         self.initialize(raw_b=self.raw_b_constraint.inverse_transform(init_b))
 
-        # set the parameter prior
-        # if a_prior is not None:
-        #     self.register_prior(
-        #         "a_prior",
-        #         a_prior,
-        #         lambda m: m.a,
-        #         lambda m, v : m._set_a(v),
-        #     )
         if b_prior is not None:
             self.register_prior(
                 "b_prior",
                 b_prior,
                 lambda m: m.b,
-                lambda m, v : m._set_b(v),
+                lambda m, v: m._set_b(v),
             )
-
-    # set the 'actual' paramters
-    # @property
-    # def a(self):
-    #     return self.raw_a_constraint.transform(self.raw_a)
-
-    # @a.setter
-    # def a(self, value):
-    #     return self._set_a(value)
-
-    # def _set_a(self, value):
-    #     if not torch.is_tensor(value):
-    #         value = torch.as_tensor(value).to(self.raw_a)
-    #     self.initialize(raw_a=self.raw_a_constraint.inverse_transform(value))
 
     @property
     def b(self):
@@ -383,15 +342,6 @@ class InvertedSigmoidKernel(SigmoidKernel):
     @a.setter
     def a(self, value):
         self.sigmoid_kernel.a = value
-
-    # @property
-    # def a(self):
-    #     """Delegate a parameter to the original SigmoidKernel."""
-    #     return self.sigmoid_kernel.a
-
-    # @a.setter
-    # def a(self, value):
-    #     self.sigmoid_kernel.a = value 
 
     @property
     def b(self):

--- a/src/rating_gp/pipeline.py
+++ b/src/rating_gp/pipeline.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
-from numpy.typing import ArrayLike
 from sklearn.base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import FunctionTransformer, StandardScaler
-from xarray import DataArray
 from discontinuum.pipeline import MetadataManager
 
 

--- a/src/rating_gp/plot.py
+++ b/src/rating_gp/plot.py
@@ -11,14 +11,11 @@ import numpy as np
 import pandas as pd
 from discontinuum.engines.base import is_fitted
 from discontinuum.plot import BasePlotMixin
-from scipy.stats import norm
-from rating_gp.models.kernels import SigmoidKernel
 import xarray as xr
 from xarray import DataArray
-from xarray.plot.utils import label_from_attrs
 
 if TYPE_CHECKING:
-    from typing import Dict, Optional, Union
+    from typing import Optional, Union
     from datetime import datetime
     from matplotlib.pyplot import Axes
     from xarray import Dataset

--- a/src/rating_gp/providers/usgs.py
+++ b/src/rating_gp/providers/usgs.py
@@ -8,12 +8,11 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 import xarray as xr
-from dataretrieval import nwis, wqp
+from dataretrieval import waterdata
 from discontinuum.providers.base import MetaData
 from loadest_gp.providers.usgs import get_metadata
 
 if TYPE_CHECKING:
-    # from pandas import DataFrame
     from typing import Dict, List, Optional, Union
 
     from xarray import Dataset
@@ -82,7 +81,7 @@ USGSStage = USGSParameter(
 )
 
 NWISStage = NWISColumn(
-    column_name="gage_height_va",
+    column_name="stage",
     standard_name="stage",
     long_name="Stream stage",
     units="meters",
@@ -90,7 +89,7 @@ NWISStage = NWISColumn(
 )
 
 NWISDischarge = NWISColumn(
-    column_name="discharge_va",
+    column_name="discharge",
     standard_name="discharge",
     long_name="Stream discharge",
     units="cubic meters per second",
@@ -98,7 +97,7 @@ NWISDischarge = NWISColumn(
 )
 
 NWISDischargeUnc = NWISColumn(
-    column_name="measured_rating_diff",
+    column_name="measurement_rated",
     standard_name="discharge_unc",
     long_name=("Stream discharge uncertainty estimated from qualitative "
                "measurement rating codes"),
@@ -112,7 +111,7 @@ def get_daily_stage(
     start_date: str,
     end_date: str,
 ) -> Dataset:
-    """Get daily data from the USGS NWIS API.
+    """Get daily data from the USGS Water Data API.
 
     Parameters
     ----------
@@ -122,8 +121,6 @@ def get_daily_stage(
         Start date in the format 'yyyy-mm-dd'.
     end_date : str
         End date in the format 'yyyy-mm-dd'.
-    params : List[USGSParameter], optional
-        List of parameters to retrieve. The default is flow only `[USGSFlow]`.
 
     Returns
     -------
@@ -131,27 +128,34 @@ def get_daily_stage(
         Dataset with the requested data.
     """
     param = USGSStage
-    df, _ = nwis.get_dv(
-        sites=site,
-        start=start_date,
-        end=end_date,
-        parameterCd=param.pcode,
-        )
+
+    if not site.startswith("USGS-"):
+        monitoring_location_id = "USGS-" + site
+    else:
+        monitoring_location_id = site
+
+    time_range = f"{start_date}/{end_date}"
+
+    df, _ = waterdata.get_daily(
+        monitoring_location_id=monitoring_location_id,
+        parameter_code=param.pcode,
+        time=time_range,
+    )
 
     if len(df) == 0:
         raise ValueError("No daily stage data is available for USGS site "
                          f"number: {site}")
 
-    # rename columns
-    df = df.rename(columns={param.pcode + param.suffix: param.name})
-    # drop columns
-    df = df[[param.name]]
+    # waterdata returns long format with 'time' and 'value' columns
+    df = df[["time", "value"]].copy()
+    df = df.rename(columns={"value": param.name})
+    df = df.set_index("time")
+
     # remove timezone for xarray compatibility
-    df.index = df.index.tz_localize(None)
+    if hasattr(df.index, "tz") and df.index.tz is not None:
+        df.index = df.index.tz_localize(None)
 
     ds = xr.Dataset.from_dataframe(df)
-    # rename "datetime" to "time", which is xarray convention
-    ds = ds.rename({"datetime": "time"})
 
     # set metadata
     ds.attrs = get_metadata(site).__dict__
@@ -168,31 +172,31 @@ def get_measurements(
         start_date: str,
         end_date: str,
 ):
-    """Get discharge measurements from the USGS NWIS API.
+    """Get discharge measurements from the USGS Water Data API.
 
     Parameters
     ----------
     site : str
-        Water Quality Portal site id; e.g., 'USGS-12345678'.
+        USGS site number; e.g., '03339000'.
     start_date : str
         Start date in the format 'YYYY-MM-DD'.
     end_date : str
         End date in the format 'YYYY-MM-DD'.
     """
-    # df, _ = nwis.get_discharge_measurements(
-    #     sites=site,
-    #     start=start_date,
-    #     end=end_date,
-    #     format="rdb_expanded",
-    # )
-    # Need this till get_discharge_measurements update is uploaded
-    response = nwis.query_waterdata(
-        'measurements', ssl_check=True, format="rdb_expanded",
-        site_no=site, begin_date=start_date, end_date=end_date,
-    )
-    df = nwis._read_rdb(response.text)
+    if not site.startswith("USGS-"):
+        monitoring_location_id = "USGS-" + site
+    else:
+        monitoring_location_id = site
 
-    return read_measurements_df(df)    
+    time_range = f"{start_date}/{end_date}"
+
+    df, _ = waterdata.get_field_measurements(
+        monitoring_location_id=monitoring_location_id,
+        parameter_code="00060,00065",
+        time=time_range,
+    )
+
+    return read_measurements_df(df)
 
 
 def read_measurements_df(df: pd.DataFrame) -> xr.Dataset:
@@ -201,106 +205,94 @@ def read_measurements_df(df: pd.DataFrame) -> xr.Dataset:
     Parameters
     ----------
     df : pd.DataFrame
-        Dataframe from `dataretrieval.nwis.get_discharge_measurements()`
+        Dataframe from `waterdata.get_field_measurements()`
 
     Returns
     -------
     xr.Dataset
-    
+
     Example
     -------
-    >>> from dataretrieval import nwis
+    >>> from dataretrieval import waterdata
     >>> from rating_gp.providers.usgs import read_measurements_df
-    >>> df, _ = nwis.get_discharge_measurements(
-        sites='03339000',
-        start='2020-01-01',
-        end='2020-12-31',
-        format='rdb_expanded',
+    >>> df, _ = waterdata.get_field_measurements(
+        monitoring_location_id='USGS-03339000',
+        parameter_code='00060,00065',
+        time='2020-01-01/2020-12-31',
         )
     >>> ds = read_measurements_df(df)
     """
+    # The waterdata API returns a long-format DataFrame with columns:
+    # time, parameter_code, value, measurement_rated, control_condition, etc.
 
-    # assert the correct columns are present
-    required_columns = [
-        "measurement_dt",
-        "gage_height_va",
-        "discharge_va",
-        "q_meas_used_fg",
-        "control_type_cd",
-        "measured_rating_diff",
-        "streamflow_method",
-        NWISStage.column_name,
-        NWISDischarge.column_name,
-    ]
+    # Pivot from long to wide format, aligning stage and discharge by time
+    pivot_values = ["value", "measurement_rated"]
+    if "control_condition" in df.columns:
+        pivot_values.append("control_condition")
 
-    missing_columns = set(required_columns) - set(df.columns)
-    if missing_columns:
-        raise ValueError(
-            f"Missing required columns in the DataFrame: {missing_columns}"
-        )
-
-    # covert timezone to UTC? ignore for now
-    df.index = pd.to_datetime(
-        df["measurement_dt"],
-        format="ISO8601",
+    pivot_df = df.pivot_table(
+        index="time",
+        columns="parameter_code",
+        values=pivot_values,
+        aggfunc="first",
     )
-    df.index.name = "time"
-    # df.index = df.index.tz_localize(None)
-    df = df.rename(
-        columns={
-            NWISStage.column_name: NWISStage.standard_name,
-            NWISDischarge.column_name: NWISDischarge.standard_name,
-            }
-        )
-    
-    # Process the control_type_cd column
-    df["control_type_cd"] = (
-        df["control_type_cd"]
-        .fillna("Unspecified")
-        .astype("category")
-        )
-    
-    # Filter any measurements that are not used in the rating
-    mask = df["q_meas_used_fg"].str.lower().isin(['yes', 'y'])
-    df = df[mask]
 
-    num_not_used = (~mask).sum()
-    if num_not_used > 0:
-        warnings.warn(
-            f"{num_not_used} measurements were not used in the rating and "
-            "will be dropped from the dataset.",
-            UserWarning,
+    # Flatten MultiIndex columns: ('value', '00060') -> 'value_00060'
+    pivot_df.columns = [f"{c[0]}_{c[1]}" for c in pivot_df.columns]
+
+    # Rename columns to standard names
+    rename_map = {
+        "value_00065": "stage",
+        "value_00060": "discharge",
+        "measurement_rated_00060": "measured_rating_diff",
+        "control_condition_00060": "control_type_cd",
+    }
+    pivot_df = pivot_df.rename(columns=rename_map)
+
+    # Timezone handling
+    if hasattr(pivot_df.index, "tz") and pivot_df.index.tz is not None:
+        pivot_df.index = pivot_df.index.tz_convert("UTC").tz_localize(None)
+    pivot_df.index.name = "time"
+
+    # Ensure required columns exist
+    for col in ["stage", "discharge"]:
+        if col not in pivot_df.columns:
+            raise ValueError(f"Missing required column: {col}")
+
+    # Process the control_type_cd column
+    if "control_type_cd" in pivot_df.columns:
+        pivot_df["control_type_cd"] = (
+            pivot_df["control_type_cd"]
+            .fillna("Unspecified")
+            .astype("category")
         )
 
     # Replace other values with 'Unspecified'
-    df['measured_rating_diff'] = df['measured_rating_diff'].where(
-        df['measured_rating_diff'].isin(USGS_QUALITY_CODES.keys()),
-        'Unspecified'
-    )
+    if "measured_rating_diff" in pivot_df.columns:
+        pivot_df['measured_rating_diff'] = pivot_df['measured_rating_diff'].where(
+            pivot_df['measured_rating_diff'].isin(USGS_QUALITY_CODES.keys()),
+            'Unspecified'
+        )
 
-    df['discharge_unc_frac'] = (df['measured_rating_diff']
-                                .replace(USGS_QUALITY_CODES)
-                                .astype(float))
-
-    # Set indirect measurements as 20% uncertain regardless of quality code
-    df.loc[df['streamflow_method'] == 'QIDIR', 'discharge_unc_frac'] = 0.2
+        pivot_df['discharge_unc_frac'] = (pivot_df['measured_rating_diff']
+                                          .replace(USGS_QUALITY_CODES)
+                                          .astype(float))
+    else:
+        pivot_df['discharge_unc_frac'] = float(USGS_QUALITY_CODES['Unspecified'])
 
     # Convert fractional uncertainty to uncertainty assuming the uncertainty
     # fraction is a 2 sigma gse interval. (GSE = frac + 1)
     # (GSE -> exp(sigma_ln(Q)))
-    df['discharge_unc'] = df['discharge_unc_frac'] / 2 + 1
+    pivot_df['discharge_unc'] = pivot_df['discharge_unc_frac'] / 2 + 1
 
     # drop data that is <= 0 as we need all positive data
-    df = df[(df['stage'] > 0) & (df['discharge'] > 0)]
+    pivot_df = pivot_df[(pivot_df['stage'] > 0) & (pivot_df['discharge'] > 0)]
 
-    ds = xr.Dataset.from_dataframe(
-        df[[
-            "stage",
-            "discharge",
-            "discharge_unc",
-            "control_type_cd",
-        ]]
-        )
+    data_cols = ["stage", "discharge", "discharge_unc"]
+    if "control_type_cd" in pivot_df.columns:
+        data_cols.append("control_type_cd")
+
+    ds = xr.Dataset.from_dataframe(pivot_df[data_cols])
 
     for param in [NWISStage, NWISDischarge]:
         ds[param.name] = ds[param.name] * param.conversion

--- a/src/rating_gp/providers/usgs.py
+++ b/src/rating_gp/providers/usgs.py
@@ -2,25 +2,23 @@
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import pandas as pd
 import xarray as xr
 from dataretrieval import waterdata
-from discontinuum.providers.base import MetaData
 from loadest_gp.providers.usgs import get_metadata
 
 if TYPE_CHECKING:
-    from typing import Dict, List, Optional, Union
+    from typing import Optional
 
     from xarray import Dataset
 
 FT_TO_M = 0.3048
 FT3_TO_M3 = 0.0283168
 
-    # Quantitative values of "measured_rating_diff"
+# Quantitative values of "measured_rating_diff"
 USGS_QUALITY_CODES = {
     'Excellent': '0.02',
     'Good': '0.05',
@@ -34,15 +32,13 @@ USGS_QUALITY_CODES = {
 class NWISColumn:
     column_name: str
     standard_name: str
-    long_name: [Optional[str]] = None
-    units: [Optional[str]] = None
+    long_name: Optional[str] = None
+    units: Optional[str] = None
     conversion: float = 1.0
 
     @property
     def name(self):
-        """
-        Alias for standard_name.
-        """
+        """Alias for standard_name."""
         return self.standard_name
 
 
@@ -52,22 +48,11 @@ class USGSParameter:
     standard_name: str
     long_name: Optional[str] = ""
     units: Optional[str] = ""
-    suffix: Optional[str] = ""
     conversion: Optional[float] = 1.0
 
     @property
-    def ppcode(self):
-        """
-        Return the parameter code with a 'p' prefix, which is used by the QWData service.
-
-        """
-        return "p" + self.pcode
-
-    @property
     def name(self):
-        """
-        Alias for standard_name.
-        """
+        """Alias for standard_name."""
         return self.standard_name
 
 
@@ -76,7 +61,6 @@ USGSStage = USGSParameter(
     standard_name="stage",
     long_name="Stream stage",
     units="meters",
-    suffix="_Mean",
     conversion=FT_TO_M,
 )
 


### PR DESCRIPTION
## Summary
- Migrate `loadest_gp` and `rating_gp` providers from deprecated `dataretrieval.nwis`/`wqp` to new `dataretrieval.waterdata` module
- Fix `_cdist_backward` error in monotonic penalty by switching to finite differences
- Fix sklearn 1.8 compatibility (`NotFittedError` on pipeline transforms)
- Fix bugs: `NWISColumn` type annotations, `cached_property` with invalid params, `warnings.warn` misuse
- Clean up codebase: remove dead code, unused imports, commented-out code; modernize `super()` calls; replace `exec()` imports

## Test plan
- [x] All 6 unit tests pass on Python 3.12, 3.13, and 3.14
- [x] `rating-gp-demo.ipynb` notebook executes successfully
- [x] `loadest-gp-demo.ipynb` notebook executes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)