### PR TITLE
Fix NaN in exact-GP marginal likelihood when fitting without target_unc

### DIFF
--- a/src/rating_gp/models/gpytorch.py
+++ b/src/rating_gp/models/gpytorch.py
@@ -67,7 +67,11 @@ class RatingGPMarginalGPyTorch(
         if y_unc is not None:
             noise = y_unc
         else:
-            noise = 0.1**2 * torch.ones(y.shape[0]).reshape(1, -1)
+            # shape (n,), matching the y_unc branch and FixedNoiseGaussianLikelihood's
+            # contract; a (1, n) shape injects a spurious batch dim that makes the
+            # marginal covariance (1, n, n) and non-finite, so the exact-MLL Cholesky
+            # fails from the first iteration when fitting without target_unc.
+            noise = 0.1**2 * torch.ones(y.shape[0])
         self.likelihood = gpytorch.likelihoods.FixedNoiseGaussianLikelihood(
             noise=noise,
             learn_additional_noise=True,


### PR DESCRIPTION
## Summary

`RatingGPMarginalGPyTorch` (and any `MarginalGPyTorch` model) fails to train when
`fit(...)` is called **without** `target_unc`: the loss is `NaN` from the first
iteration and the run aborts with a Cholesky `NanError` after ~10 iterations.

## Root cause

In `build_model` (`src/rating_gp/models/gpytorch.py`), the default measurement-error
branch builds the `FixedNoiseGaussianLikelihood` noise as

```python
noise = 0.1**2 * torch.ones(y.shape[0]).reshape(1, -1)   # shape (1, n)
```

The `reshape(1, -1)` injects a spurious leading **batch dimension**. The kernel matrix
is finite `(n, n)`, but once the likelihood adds this `(1, n)` noise the marginal
covariance becomes `(1, n, n)` and **non-finite**, so the exact-MLL Cholesky fails.
`fit()`'s `nan_loss_counter` guard swallows the error for ~10 iterations before
re-raising, so it presents as a training *divergence* rather than a shape bug.

The `y_unc`-provided branch is unaffected because `DataManager.y_unc` is already
`(n,)` — which is why this only surfaces when fitting without gauging uncertainty.

## Reproduction

```python
m = RatingGPMarginalGPyTorch()
m.fit(covariates, target, iterations=100)   # no target_unc -> NanError ~iter 10
```

Tracing the marginal covariance shows the batch dim and the non-finiteness:

```
covar       finite True  shape (96, 96)
fixed noise        shape (1, 96)        # <-- spurious batch dim
marg covar  finite False shape (1, 96, 96)
cholesky FAIL
```

## Fix

Build the default noise as shape `(n,)`, matching the `y_unc` branch and gpytorch's
`FixedNoiseGaussianLikelihood` contract.

## Verification

With the fix, `RatingGPMarginalGPyTorch().fit(covariates, target, iterations=100)`
trains to completion (no `target_unc`) on several USGS rating sites, producing finite,
reasonably-calibrated predictions (e.g. test log-density −3.6 to −5.5, ~1–3 s/fit).

Found while benchmarking `rating_gp` as a candidate in an external stage–discharge
rating test harness (the harness passes no per-gauging uncertainty by default).

Environment: torch 2.12.1, gpytorch 1.15.2, Python 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)